### PR TITLE
duplicate Base64 import + Python3.9 error fix

### DIFF
--- a/DBC-Server.py
+++ b/DBC-Server.py
@@ -4,7 +4,6 @@ import base64
 from time import sleep
 from dnslib import DNSRecord, RR, QTYPE, A, MX, TXT
 from socketserver import BaseRequestHandler, UDPServer
-import base64
 from itertools import cycle
 import argparse
 import pyfiglet 
@@ -36,7 +35,7 @@ def xor_crypto_de(data):
 def xor_crypto_enc(data):
     key = "0xsp.com"
     xored = ''.join(chr(ord(x)^ord(y)) for x,y in zip(data,cycle(key)))
-    return base64.encodestring(xored.encode('utf-8')).decode('utf-8').replace('\n', '').strip()
+    return base64.encodesbytes(xored.encode('utf-8')).decode('utf-8').replace('\n', '').strip()
 
 class Exfiltrator(BaseRequestHandler, object):
     def __init__(self, *args):


### PR DESCRIPTION
removed the duplicate import base64
changed base64.encodestring to base64.encodebytes to work with python3